### PR TITLE
fix: rename config file in a deploy script

### DIFF
--- a/.github/workflows/platformatic-dynamic-workspace-deploy.yml
+++ b/.github/workflows/platformatic-dynamic-workspace-deploy.yml
@@ -22,5 +22,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           platformatic_workspace_id: ${{ secrets.PLATFORMATIC_DYNAMIC_WORKSPACE_ID }}
           platformatic_workspace_key: ${{ secrets.PLATFORMATIC_DYNAMIC_WORKSPACE_API_KEY }}
-          platformatic_config_path: ./platformatic.service.json
+          platformatic_config_path: ./platformatic.runtime.json
 


### PR DESCRIPTION
@tomashco thanks for the access. The deploy itself should work now (application startup fails). To deploy this application with a GitHub action you need to set the env in the GitHub action script.
1. Install npm dependencies for each service.
2. Set the env vars in the deploy script.
 
 You can use pnpm instead of npm. It might simplify the work with a monorepo. Here is an example of how it can be done with a pnpm:
 https://github.com/platformatic/examples/tree/main/applications/build-modular-monolith-with-platformatic#setup
 
 Ping me if you need some help with it.